### PR TITLE
HelloSora の react-native-webtckit を 2020.2.0 に更新する 

### DIFF
--- a/HelloSora/ios/Podfile.lock
+++ b/HelloSora/ios/Podfile.lock
@@ -217,7 +217,7 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/jscallinvoker (= 0.61.5)
-  - ReactNativeWebRTCKit (2020.1.0):
+  - ReactNativeWebRTCKit (2020.2.0):
     - React
     - WebRTC (~> 79.5.0)
   - RNVectorIcons (6.6.0):
@@ -345,11 +345,11 @@ SPEC CHECKSUMS:
   React-RCTText: 9ccc88273e9a3aacff5094d2175a605efa854dbe
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
-  ReactNativeWebRTCKit: 63b4d508c685ba8e5f73a0ea9ab2fcc418919f89
+  ReactNativeWebRTCKit: 82647125a72435b737731bf4d107423b85d76697
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   WebRTC: f6746a0af43dae19e67ec2c26f2e10f7c8617c86
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
 PODFILE CHECKSUM: 5820f78c43d2c28071c07753c827db9f950cfd2f
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.1

--- a/HelloSora/package.json
+++ b/HelloSora/package.json
@@ -14,7 +14,7 @@
     "react-native": "0.61.5",
     "react-native-paper": "^2.16.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "2020.1.0"
+    "react-native-webrtc-kit": "2020.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloSora/yarn.lock
+++ b/HelloSora/yarn.lock
@@ -1244,9 +1244,9 @@ acorn-walk@^6.0.1:
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
 acorn@^5.5.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
+  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
 acorn@^6.0.1:
   version "6.3.0"

--- a/HelloSora/yarn.lock
+++ b/HelloSora/yarn.lock
@@ -5550,10 +5550,10 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-webrtc-kit@2020.1.0:
-  version "2020.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.1.0.tgz#1aa0b472af1e8b1e578a2dea7db340eadfc2fd27"
-  integrity sha512-CP/BjFt3TT47EMzzW7WgWxBVz5g9/MhYtc6F6eq2VrjKvNcAsHNZUjz6A/DcOsHqa5ZY3YbOD+m3m5i+03vB6w==
+react-native-webrtc-kit@2020.2.0:
+  version "2020.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.2.0.tgz#13e0f2b650a1515b140c1142525727fb28cbf6e2"
+  integrity sha512-iKKx13zHsr4TTryBvo7k8VHyMVBGCevp0TdpTkOCJK6r220WmPcrYEl25PsNbSB+eQ3Cc4+ItUxsdZ++qJQXOA==
   dependencies:
     event-target-shim "^3.0.2"
     prop-types "^15.6.2"


### PR DESCRIPTION
dependentbot で出ていた警告の解消も含めています。