### PR TITLE
RNKit を 2020.3.1 にアップデートする

### DIFF
--- a/HelloSora/ios/Podfile.lock
+++ b/HelloSora/ios/Podfile.lock
@@ -217,7 +217,7 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/jscallinvoker (= 0.61.5)
-  - ReactNativeWebRTCKit (2020.3.0):
+  - ReactNativeWebRTCKit (2020.3.1):
     - React
     - WebRTC (~> 79.5.0)
   - RNVectorIcons (6.6.0):
@@ -345,7 +345,7 @@ SPEC CHECKSUMS:
   React-RCTText: 9ccc88273e9a3aacff5094d2175a605efa854dbe
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
-  ReactNativeWebRTCKit: 248e9ecb86dc90dbadf054ab2b73ba554eb6756e
+  ReactNativeWebRTCKit: 765680debc67721b8055fe7479d259b091a5e73d
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   WebRTC: f6746a0af43dae19e67ec2c26f2e10f7c8617c86
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b

--- a/HelloSora/package.json
+++ b/HelloSora/package.json
@@ -14,7 +14,7 @@
     "react-native": "0.61.5",
     "react-native-paper": "^2.16.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "2020.3.0"
+    "react-native-webrtc-kit": "2020.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloSora/yarn.lock
+++ b/HelloSora/yarn.lock
@@ -5262,10 +5262,10 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-webrtc-kit@2020.3.0:
-  version "2020.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.3.0.tgz#e46c6cb8353b2bcd931bf6129c6803efb8796acc"
-  integrity sha512-xFpQIYYmyskY5tYyGNDuSakj3nyl5CLkwcsvmuBv/FlFQ75z2pDrh3O2U63S7N7gzSvCD70zcvlpPqBzkaEBvQ==
+react-native-webrtc-kit@2020.3.1:
+  version "2020.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.3.1.tgz#f35b28e70f12ffc0b643e7e487ce90c3f0adf93b"
+  integrity sha512-g6qGOEyOviHQAQvhOwMgdAebggTEP+r0Zpnpjihy4SsFfNHHNlSyHCWgeoUBaz5muFB1YZBLvrfwhuV4yrI0nw==
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"


### PR DESCRIPTION
react-native-webrtc-kit のバージョンを 2020.3.1 にアップデートしました。
iOS と Android で簡単に動作確認をしています。