### PR TITLE
参照する RNKit を 2020.6.1 に更新する

### DIFF
--- a/HelloAyame/ios/Podfile.lock
+++ b/HelloAyame/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - React-cxxreact (= 0.62.0)
     - React-jsi (= 0.62.0)
     - ReactCommon/callinvoker (= 0.62.0)
-  - ReactNativeWebRTCKit (2020.6.0):
+  - ReactNativeWebRTCKit (2020.6.1):
     - React
     - WebRTC (~> 86.4240.1.2)
   - RNVectorIcons (6.6.0):
@@ -448,7 +448,7 @@ SPEC CHECKSUMS:
   React-RCTText: 91a0d0ae5434aa28fe0c89c03eb9d660ff53bd9b
   React-RCTVibration: 0630aeb11e22f87c180ca9c0c3a0a0aba780cc62
   ReactCommon: d22162ab8f1358c53dfcd0f9c4d82d38facdbc48
-  ReactNativeWebRTCKit: dcf0330f4f9744139c1f929d5a7f2aa555431a6e
+  ReactNativeWebRTCKit: 2a0acf125ca5e80597bc2233d1992c75345f34c6
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   WebRTC: 5d6be27ac7c1f762c57bc1728f9f8d279274858f
   Yoga: 9db9ff2025ad21d1ac0a8b3c85d5ac4e7c29d525

--- a/HelloAyame/package.json
+++ b/HelloAyame/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.62.0",
     "react-native-paper": "^3.6.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "^2020.6.0"
+    "react-native-webrtc-kit": "^2020.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloAyame/yarn.lock
+++ b/HelloAyame/yarn.lock
@@ -5035,10 +5035,10 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-webrtc-kit@^2020.6.0:
-  version "2020.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.6.0.tgz#c778afb04a319070fd3d77e501c866691ea86fe0"
-  integrity sha512-mbPACD0gwiy6Kmatzfcd3mcrpry9Ce6zYC1hyJpMOGh7XKIoJwm8xsPPzpUmjQhjfaWVveb9VGudLdCWwUTiIA==
+react-native-webrtc-kit@^2020.6.1:
+  version "2020.6.1"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.6.1.tgz#443a9bf2d4a1b42c64a45427772f085589c02a4b"
+  integrity sha512-Izq7Iu2TR8C0TST83q1gO0UKG/p3aLRl1J+TauwHZ3R2SXutLTSUXPo5ASUA2k6N2zOM24Prt9S+xPihMhFZBg==
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"

--- a/HelloSora/ios/Podfile.lock
+++ b/HelloSora/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - ReactNativeWebRTCKit (2020.6.0):
+  - ReactNativeWebRTCKit (2020.6.1):
     - React
     - WebRTC (~> 86.4240.1.2)
   - RNVectorIcons (6.6.0):
@@ -462,7 +462,7 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  ReactNativeWebRTCKit: dcf0330f4f9744139c1f929d5a7f2aa555431a6e
+  ReactNativeWebRTCKit: 2a0acf125ca5e80597bc2233d1992c75345f34c6
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   WebRTC: 5d6be27ac7c1f762c57bc1728f9f8d279274858f
   Yoga: 3ebccbdd559724312790e7742142d062476b698e

--- a/HelloSora/package.json
+++ b/HelloSora/package.json
@@ -14,7 +14,7 @@
     "react-native": "0.62.2",
     "react-native-paper": "^2.16.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "^2020.6.0"
+    "react-native-webrtc-kit": "^2020.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloSora/yarn.lock
+++ b/HelloSora/yarn.lock
@@ -5195,10 +5195,10 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-webrtc-kit@^2020.6.0:
-  version "2020.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.6.0.tgz#c778afb04a319070fd3d77e501c866691ea86fe0"
-  integrity sha512-mbPACD0gwiy6Kmatzfcd3mcrpry9Ce6zYC1hyJpMOGh7XKIoJwm8xsPPzpUmjQhjfaWVveb9VGudLdCWwUTiIA==
+react-native-webrtc-kit@^2020.6.1:
+  version "2020.6.1"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.6.1.tgz#443a9bf2d4a1b42c64a45427772f085589c02a4b"
+  integrity sha512-Izq7Iu2TR8C0TST83q1gO0UKG/p3aLRl1J+TauwHZ3R2SXutLTSUXPo5ASUA2k6N2zOM24Prt9S+xPihMhFZBg==
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"


### PR DESCRIPTION
## 変更内容

- HelloSora と HelloAyame の参照する [react-native-webrtc-kit](https://github.com/react-native-webrtc-kit/react-native-webrtc-kit) を 2020.6.1 に更新しました