### PR TITLE
GitHub Actions で利用しているソフトウェアのバージョンを更新する

### DIFF
--- a/.github/workflows/helloayame_android.yml
+++ b/.github/workflows/helloayame_android.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         node-version: [11.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: set up Java
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/helloayame_android.yml
+++ b/.github/workflows/helloayame_android.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [11.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - name: set up Java

--- a/.github/workflows/helloayame_ios.yml
+++ b/.github/workflows/helloayame_ios.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         node-version: [11.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/helloayame_ios.yml
+++ b/.github/workflows/helloayame_ios.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [11.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/hellosora_android.yml
+++ b/.github/workflows/hellosora_android.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         node-version: [11.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/hellosora_android.yml
+++ b/.github/workflows/hellosora_android.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [11.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - name: set up JDK 1.8

--- a/.github/workflows/hellosora_ios.yml
+++ b/.github/workflows/hellosora_ios.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         node-version: [11.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/hellosora_ios.yml
+++ b/.github/workflows/hellosora_ios.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [11.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## 変更内容

- 以下のソフトウェアを更新しました
  - actions/checkout: v1 -> v2 
  - Node.js: v11 -> v14