### PR TITLE
WebRTC M88 の対応 + HelloAyame の安定性の改善

### DIFF
--- a/HelloAyame/App.tsx
+++ b/HelloAyame/App.tsx
@@ -72,18 +72,22 @@ const App: () => React.ReactNode = () => {
     <View style={styles.body}>
       <View style={styles.div_content}>
         <View style={styles.div_header}>
+        {(conn !== null && sender !== null && sender.track !== null) &&
           <RTCVideoView
             style={styles.videoview}
-            track={sender ? sender.track : null}
+            track={sender.track}
             objectFit={objectFit}
           />
+        }
         </View>
         <View style={styles.div_header}>
+        {(conn !== null && receiver !== null && receiver.track !== null) &&
           <RTCVideoView
             style={styles.videoview}
-            track={receiver ? receiver.track : null}
+            track={receiver.track}
             objectFit={objectFit}
           />
+        }
         </View>
         <View style={{flex: 1, flexDirection: 'column'}}>
           <TextInput

--- a/HelloAyame/ios/Podfile.lock
+++ b/HelloAyame/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - React-cxxreact (= 0.62.0)
     - React-jsi (= 0.62.0)
     - ReactCommon/callinvoker (= 0.62.0)
-  - ReactNativeWebRTCKit (2020.6.1):
+  - ReactNativeWebRTCKit (2020.7.0):
     - React
     - WebRTC (~> 88.4324.2.0)
   - RNVectorIcons (6.6.0):
@@ -448,7 +448,7 @@ SPEC CHECKSUMS:
   React-RCTText: 91a0d0ae5434aa28fe0c89c03eb9d660ff53bd9b
   React-RCTVibration: 0630aeb11e22f87c180ca9c0c3a0a0aba780cc62
   ReactCommon: d22162ab8f1358c53dfcd0f9c4d82d38facdbc48
-  ReactNativeWebRTCKit: 6fb99e334ae130f3fca2754e5de1c10919665552
+  ReactNativeWebRTCKit: 3ae60ec10d39a573ffb905bc1f65e2c32c9e7fb3
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   WebRTC: a910306b4322982482a44a8a8e9316e44f639b47
   Yoga: 9db9ff2025ad21d1ac0a8b3c85d5ac4e7c29d525

--- a/HelloAyame/ios/Podfile.lock
+++ b/HelloAyame/ios/Podfile.lock
@@ -294,10 +294,10 @@ PODS:
     - ReactCommon/callinvoker (= 0.62.0)
   - ReactNativeWebRTCKit (2020.6.1):
     - React
-    - WebRTC (~> 86.4240.1.2)
+    - WebRTC (~> 88.4324.2.0)
   - RNVectorIcons (6.6.0):
     - React
-  - WebRTC (86.4240.1.2)
+  - WebRTC (88.4324.2.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -448,9 +448,9 @@ SPEC CHECKSUMS:
   React-RCTText: 91a0d0ae5434aa28fe0c89c03eb9d660ff53bd9b
   React-RCTVibration: 0630aeb11e22f87c180ca9c0c3a0a0aba780cc62
   ReactCommon: d22162ab8f1358c53dfcd0f9c4d82d38facdbc48
-  ReactNativeWebRTCKit: 2a0acf125ca5e80597bc2233d1992c75345f34c6
+  ReactNativeWebRTCKit: 6fb99e334ae130f3fca2754e5de1c10919665552
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
-  WebRTC: 5d6be27ac7c1f762c57bc1728f9f8d279274858f
+  WebRTC: a910306b4322982482a44a8a8e9316e44f639b47
   Yoga: 9db9ff2025ad21d1ac0a8b3c85d5ac4e7c29d525
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/HelloAyame/package.json
+++ b/HelloAyame/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.62.0",
     "react-native-paper": "^3.6.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88"
+    "react-native-webrtc-kit": "^2020.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloAyame/package.json
+++ b/HelloAyame/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.62.0",
     "react-native-paper": "^3.6.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "^2020.6.1"
+    "react-native-webrtc-kit": "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloAyame/yarn.lock
+++ b/HelloAyame/yarn.lock
@@ -5035,10 +5035,9 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-webrtc-kit@^2020.6.1:
+"react-native-webrtc-kit@git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88":
   version "2020.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.6.1.tgz#443a9bf2d4a1b42c64a45427772f085589c02a4b"
-  integrity sha512-Izq7Iu2TR8C0TST83q1gO0UKG/p3aLRl1J+TauwHZ3R2SXutLTSUXPo5ASUA2k6N2zOM24Prt9S+xPihMhFZBg==
+  resolved "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#56aa82076a858037fa59ccad5621552cd5f77824"
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"

--- a/HelloAyame/yarn.lock
+++ b/HelloAyame/yarn.lock
@@ -5035,9 +5035,10 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-"react-native-webrtc-kit@git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88":
-  version "2020.6.1"
-  resolved "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#56aa82076a858037fa59ccad5621552cd5f77824"
+react-native-webrtc-kit@^2020.7.0:
+  version "2020.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.7.0.tgz#abbe9be277a1b9b75629a4261f6847167db02f74"
+  integrity sha512-8R7jQpODElHUBxly6lJOGioH7kmspmahaw5It+y4nca8rXAAjT4r7ZCxauikRZBVtc98EYG/OnIQ3YwFd6BglQ==
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"

--- a/HelloSora/ios/Podfile.lock
+++ b/HelloSora/ios/Podfile.lock
@@ -294,10 +294,10 @@ PODS:
     - ReactCommon/callinvoker (= 0.62.2)
   - ReactNativeWebRTCKit (2020.6.1):
     - React
-    - WebRTC (~> 86.4240.1.2)
+    - WebRTC (~> 88.4324.2.0)
   - RNVectorIcons (6.6.0):
     - React
-  - WebRTC (86.4240.1.2)
+  - WebRTC (88.4324.2.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -462,9 +462,9 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  ReactNativeWebRTCKit: a737f2f2e73dbfab1b609a65e161cf228cc82e28
+  ReactNativeWebRTCKit: 6fb99e334ae130f3fca2754e5de1c10919665552
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
-  WebRTC: e3b7bd6a2fe5416fd355cfd525d90d8d8bb865b4
+  WebRTC: a910306b4322982482a44a8a8e9316e44f639b47
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/HelloSora/ios/Podfile.lock
+++ b/HelloSora/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - ReactNativeWebRTCKit (2020.6.1):
+  - ReactNativeWebRTCKit (2020.7.0):
     - React
     - WebRTC (~> 88.4324.2.0)
   - RNVectorIcons (6.6.0):
@@ -462,7 +462,7 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  ReactNativeWebRTCKit: 6fb99e334ae130f3fca2754e5de1c10919665552
+  ReactNativeWebRTCKit: 3ae60ec10d39a573ffb905bc1f65e2c32c9e7fb3
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   WebRTC: a910306b4322982482a44a8a8e9316e44f639b47
   Yoga: 3ebccbdd559724312790e7742142d062476b698e

--- a/HelloSora/package.json
+++ b/HelloSora/package.json
@@ -14,7 +14,7 @@
     "react-native": "0.62.2",
     "react-native-paper": "^2.16.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88"
+    "react-native-webrtc-kit": "^2020.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloSora/package.json
+++ b/HelloSora/package.json
@@ -14,7 +14,7 @@
     "react-native": "0.62.2",
     "react-native-paper": "^2.16.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-webrtc-kit": "^2020.6.1"
+    "react-native-webrtc-kit": "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/HelloSora/yarn.lock
+++ b/HelloSora/yarn.lock
@@ -5195,10 +5195,9 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-webrtc-kit@^2020.6.1:
+"react-native-webrtc-kit@git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88":
   version "2020.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.6.1.tgz#443a9bf2d4a1b42c64a45427772f085589c02a4b"
-  integrity sha512-Izq7Iu2TR8C0TST83q1gO0UKG/p3aLRl1J+TauwHZ3R2SXutLTSUXPo5ASUA2k6N2zOM24Prt9S+xPihMhFZBg==
+  resolved "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#56aa82076a858037fa59ccad5621552cd5f77824"
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"

--- a/HelloSora/yarn.lock
+++ b/HelloSora/yarn.lock
@@ -5195,9 +5195,10 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-"react-native-webrtc-kit@git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#feature/m88":
-  version "2020.6.1"
-  resolved "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git#56aa82076a858037fa59ccad5621552cd5f77824"
+react-native-webrtc-kit@^2020.7.0:
+  version "2020.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-webrtc-kit/-/react-native-webrtc-kit-2020.7.0.tgz#abbe9be277a1b9b75629a4261f6847167db02f74"
+  integrity sha512-8R7jQpODElHUBxly6lJOGioH7kmspmahaw5It+y4nca8rXAAjT4r7ZCxauikRZBVtc98EYG/OnIQ3YwFd6BglQ==
   dependencies:
     base64-js "^1.3.1"
     event-target-shim "^3.0.2"


### PR DESCRIPTION
## 変更内容

- HelloAyame, HelloSora が参照する React Native WebRTC Kit を、 WebRTC M88 に対応した 2020.7.0 に更新しました
- HelloAyame の RTCVideoView の表示条件を HelloSora と揃えました
  - 接続を切断する際に、 RTCVideoView が解放済みのリソースにアクセスしてエラーが発生するケースがありました
  - HelloSora で同様の問題を改善したことがあり、その修正内容を今回 HelloAyame にも移植しました  https://github.com/react-native-webrtc-kit/react-native-webrtc-kit-samples/pull/11